### PR TITLE
Add ability to specify and view salary information for job postings

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -36,6 +36,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      salary: "",
       notes: "",
     },
   });
@@ -156,6 +157,25 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. $120k–$150k or $130,000"
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -41,6 +41,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      salary: prospect.salary ?? "",
       notes: prospect.notes ?? "",
     },
   });
@@ -160,6 +161,25 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. $120k–$150k or $130,000"
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-edit-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -102,6 +102,12 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.salary && (
+            <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400" data-testid={`text-salary-${prospect.id}`}>
+              <DollarSign className="w-3 h-3" />
+              {prospect.salary}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,6 +55,8 @@ export async function registerRoutes(
       updates.interestLevel = level;
     }
 
+    if (body.salary !== undefined) updates.salary = body.salary || null;
+
     const updated = await storage.updateProspect(id, updates);
     res.json(updated);
   });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -21,6 +21,7 @@ export const prospects = pgTable("prospects", {
   jobUrl: text("job_url"),
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
+  salary: text("salary"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -34,6 +35,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
+  salary: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
Introduce a new optional 'salary' text field to the prospect schema and database. Update add and edit forms to include this field, and display the salary on the prospect card when provided. The server route handler has also been modified to accept and update the salary.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: bb0dfbe6-5c23-436e-aa43-7ad96cdac0a6
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: bbc97bd9-607b-4c22-be1f-bd1dddfdc440
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/425177bd-3c21-4919-86d8-b277b4315d73/bb0dfbe6-5c23-436e-aa43-7ad96cdac0a6/Dtaobfi
Replit-Helium-Checkpoint-Created: true